### PR TITLE
Some feedback/suggestions on the PR

### DIFF
--- a/test/connextModule.test.ts
+++ b/test/connextModule.test.ts
@@ -1,21 +1,23 @@
-import { expect } from "chai"
-import "@nomicfoundation/hardhat-ethers"
-import hre, { ethers, deployments, getNamedAccounts } from "hardhat"
-import createAdapter from "./createEIP1193"
+import hre, { ethers } from "hardhat"
 import { deployFactories, deployMastercopy, deployProxy } from "zodiac-core"
 import { AbiCoder, ZeroHash } from "ethers"
+import { expect } from "chai"
+
+import { loadFixture } from "@nomicfoundation/hardhat-toolbox/network-helpers"
+
+import createAdapter from "./createEIP1193"
+
 import { ConnextModule__factory } from "../typechain-types"
 
 const AddressOne = "0x0000000000000000000000000000000000000001"
 const transferId = "0x0000000000000000000000000000000000000000000000000000000000000001"
 
 const setup = async () => {
-  const [deployer] = await ethers.getSigners()
+  const [deployer, owner, connext, other] = await ethers.getSigners()
   const eip1193Provider = createAdapter({
     provider: hre.network.provider,
     signer: deployer,
   })
-  const testSigner = deployer
   const Avatar = await ethers.getContractFactory("TestAvatar")
   const Token = await ethers.getContractFactory("TestToken")
   const ConnextModule = await ethers.getContractFactory("ConnextModule")
@@ -25,59 +27,89 @@ const setup = async () => {
   const avatarAddress = await avatar.getAddress()
   const token = await Token.deploy(18)
   const params = {
-    owner: testSigner.address,
+    owner: owner.address,
     avatar: avatarAddress,
     target: avatarAddress,
     originSender: AddressOne,
     origin: 1337,
-    connextAddress: testSigner.address,
+    connextAddress: connext.address,
   }
   const paramTypes = ["address", "address", "address", "address", "uint32", "address"]
 
-  await deployFactories({ provider: eip1193Provider })
-
-  const connextModule = await deployMastercopy({
-    bytecode: ConnextModule.bytecode,
-    constructorArgs: {
-      types: paramTypes,
-      values: [params.owner, params.avatar, params.target, params.originSender, params.origin, params.connextAddress],
-    },
-    salt: ZeroHash,
-    provider: eip1193Provider,
-  })
-
-  // const connextModule = await ConnextModule.deploy(
-  //   params.owner,
-  //   params.avatar,
-  //   params.target,
-  //   params.originSender,
-  //   params.origin,
-  //   params.connextAddress,
-  // )
+  const connextModule = await ConnextModule.deploy(
+    params.owner,
+    params.avatar,
+    params.target,
+    params.originSender,
+    params.origin,
+    params.connextAddress,
+  )
   // const connextModAddress = await connextModule.address()
   const button = await Button.deploy()
   await button.waitForDeployment()
-  await avatar.enableModule(connextModule.address)
-
-  const ModuleProxyFactory = await ethers.getContractFactory("ModuleProxyFactory")
-  const moduleProxyFactory = await ModuleProxyFactory.deploy()
+  await avatar.enableModule(await connextModule.getAddress())
 
   return {
+    signers: {
+      owner,
+      connext,
+      other,
+    },
     button,
-    connextModule,
+    connextModule: connextModule.connect(owner),
     avatar,
     token,
-    testSigner,
-    masterCopy: ConnextModule__factory.connect(connextModule.address, deployer),
     params,
     paramTypes,
     eip1193Provider,
   }
 }
+
+async function setUpWithProxy() {
+  const { eip1193Provider, params, paramTypes } = await loadFixture(setup)
+  const values = [params.owner, params.avatar, params.target, params.originSender, params.origin, params.connextAddress]
+
+  await deployFactories({ provider: eip1193Provider })
+  const { address: mastercopy } = await deployMastercopy({
+    bytecode: (await ethers.getContractFactory("ConnextModule")).bytecode,
+    constructorArgs: {
+      types: ["address", "address", "address", "address", "uint32", "address"],
+      values: [AddressOne, AddressOne, AddressOne, AddressOne, 1, AddressOne],
+    },
+    salt: ZeroHash,
+    provider: eip1193Provider,
+  })
+
+  const { address } = await deployProxy({
+    mastercopy,
+    setupArgs: {
+      types: paramTypes,
+      values,
+    },
+    saltNonce: "0xfa",
+    provider: eip1193Provider,
+  })
+
+  return {
+    eip1193Provider,
+    params,
+    paramTypes,
+    proxyAddress: address,
+    mastercopyAddress: mastercopy,
+  }
+}
+
 describe("ConnextModule", function () {
   describe("xReceive()", function () {
     it("Should successfully transfer token balance to avatar and tell avatar to push button", async function () {
-      const { button, masterCopy, testSigner, token, avatar } = await setup()
+      const {
+        signers: { connext },
+        connextModule,
+        button,
+        params,
+        token,
+        avatar,
+      } = await loadFixture(setup)
 
       const tx = await button.push.populateTransaction()
       const buttonAddress = await button.getAddress()
@@ -92,19 +124,18 @@ describe("ConnextModule", function () {
       )
 
       // send some tokens to the connext module, simulates what the connext contract would do.
-      await token.transfer(await masterCopy.getAddress(), 1000)
+      await token.transfer(await connextModule.getAddress(), 1000)
       // check current number of pushes
       expect(await button.pushes()).to.equal(0)
       // pass token transfer instructions and button push message to connext module.
       // ensure it emits buttonPushed event with avatar as pusher.
-      const tokenAddress = await token.getAddress()
       expect(
-        await masterCopy.connect(testSigner).xReceive(
+        await connextModule.connect(connext).xReceive(
           transferId, // _transferId
           1000, // _amount
-          tokenAddress, // _asset
-          AddressOne, // _originSender
-          1337, // _origin
+          await token.getAddress(), // _asset
+          params.originSender, // _originSender
+          params.origin, // _origin
           data, // _callData
         ),
       )
@@ -117,7 +148,13 @@ describe("ConnextModule", function () {
     })
 
     it("Should revert if origin is incorrect", async function () {
-      const { button, masterCopy, testSigner, token } = await setup()
+      const {
+        signers: { connext },
+        params,
+        button,
+        connextModule,
+        token,
+      } = await loadFixture(setup)
 
       const tx = await button.push.populateTransaction()
       const buttonAddress = await button.getAddress()
@@ -133,51 +170,60 @@ describe("ConnextModule", function () {
       // check current number of pushes
       expect(await button.pushes()).to.equal(0)
       // pass token transfer instructions and button push message to connext module.
-      const tokenAddress = await token.getAddress()
       await expect(
-        masterCopy.connect(testSigner).xReceive(
-          transferId, // _transferId
+        connextModule.connect(connext).xReceive(
+          transferId,
           0, // _amount
-          tokenAddress, // _asset
-          AddressOne, // _originSender
-          0xdead, // _origin
-          data, // _callData
+          await token.getAddress(),
+          params.originSender,
+          0xdead, // incorrect origin
+          data,
         ),
-      ).to.be.revertedWithCustomError(masterCopy, "OriginOnly()")
-    }),
-      it("Should revert if originSender is incorrect", async function () {
-        const { button, masterCopy, testSigner, token } = await setup()
+      ).to.be.revertedWithCustomError(connextModule, "OriginOnly()")
+    })
 
-        const tx = await button.push.populateTransaction()
-        const buttonAddress = await button.getAddress()
-        const data = new AbiCoder().encode(
-          ["address", "uint256", "bytes", "bool"],
-          [
-            buttonAddress, // to
-            0, // value
-            tx.data, // data
-            0, // operation
-          ],
-        )
-        // check current number of pushes
-        expect(await button.pushes()).to.equal(0)
-        // pass token transfer instructions and button push message to connext module.
-        const tokenAddress = await token.getAddress()
-        await expect(
-          masterCopy.connect(testSigner).xReceive(
-            transferId, // _transferId
-            0, // _amount
-            tokenAddress, // _asset
-            testSigner.address, // _originSender
-            1337, // _origin
-            data, // _callData
-          ),
-        ).to.be.revertedWithCustomError(masterCopy, "OriginSenderOnly()")
-      })
+    it("Should revert if originSender is incorrect", async function () {
+      const {
+        signers: { connext, other },
+        params,
+        connextModule,
+        button,
+        token,
+      } = await loadFixture(setup)
+
+      const tx = await button.push.populateTransaction()
+      const buttonAddress = await button.getAddress()
+      const data = new AbiCoder().encode(
+        ["address", "uint256", "bytes", "bool"],
+        [
+          buttonAddress, // to
+          0, // value
+          tx.data, // data
+          0, // operation
+        ],
+      )
+      // check current number of pushes
+      expect(await button.pushes()).to.equal(0)
+      // pass token transfer instructions and button push message to connext module.
+      await expect(
+        connextModule.connect(connext).xReceive(
+          transferId,
+          0, // _amount
+          await token.getAddress(),
+          other.address, // originSender incorrect
+          params.origin, // ok
+          data,
+        ),
+      ).to.be.revertedWithCustomError(connextModule, "OriginSenderOnly()")
+    })
 
     it("Should revert if called by account other than connext", async function () {
-      const { button, masterCopy, token } = await setup()
-      const [, nonConnextAccount] = await ethers.getSigners()
+      const {
+        signers: { other },
+        connextModule,
+        button,
+        token,
+      } = await loadFixture(setup)
 
       const tx = await button.push.populateTransaction()
       const buttonAddress = await button.getAddress()
@@ -195,7 +241,7 @@ describe("ConnextModule", function () {
       expect(await button.pushes()).to.equal(0)
       // pass token transfer instructions and button push message to connext module.
       await expect(
-        masterCopy.connect(nonConnextAccount).xReceive(
+        connextModule.connect(other).xReceive(
           transferId, // _transferId
           0, // _amount
           tokenAddress, // _asset
@@ -203,55 +249,66 @@ describe("ConnextModule", function () {
           1337, // _origin
           data, // _callData
         ),
-      ).to.be.revertedWithCustomError(masterCopy, "ConnextOnly()")
-    }),
-      it("Should revert if token balance is less than _amount", async function () {
-        const { button, masterCopy, testSigner, token } = await setup()
+      ).to.be.revertedWithCustomError(connextModule, "ConnextOnly()")
+    })
+    it("Should revert if token balance is less than _amount", async function () {
+      const {
+        signers: { connext },
+        params,
+        connextModule,
+        button,
+        token,
+      } = await loadFixture(setup)
 
-        const tx = await button.push.populateTransaction()
-        const buttonAddress = await button.getAddress()
-        const data = new AbiCoder().encode(
-          ["address", "uint256", "bytes", "bool"],
-          [
-            buttonAddress, // to
-            0, // value
-            tx.data, // data
-            0, // operation
-          ],
-        )
-        // check current number of pushes
-        expect(await button.pushes()).to.equal(0)
-        const tokenAddress = await token.getAddress()
-        // pass token transfer instructions and button push message to connext module.
-        await expect(
-          masterCopy.connect(testSigner).xReceive(
-            transferId, // _transferId
-            1000, // _amount
-            tokenAddress, // _asset
-            AddressOne, // _originSender
-            1337, // _origin
-            data, // _callData
-          ),
-        ).to.be.reverted //handle de specific error
-      })
+      const tx = await button.push.populateTransaction()
+      const buttonAddress = await button.getAddress()
+      const data = new AbiCoder().encode(
+        ["address", "uint256", "bytes", "bool"],
+        [
+          buttonAddress, // to
+          0, // value
+          tx.data, // data
+          0, // operation
+        ],
+      )
+      // check current number of pushes
+      expect(await button.pushes()).to.equal(0)
+
+      // pass token transfer instructions and button push message to connext module.
+      await expect(
+        connextModule.connect(connext).xReceive(
+          transferId,
+          1000, // _amount
+          await token.getAddress(),
+          params.originSender,
+          params.origin,
+          data,
+        ),
+      ).to.be.reverted //handle de specific error
+    })
 
     it("Should revert if module transaction fails", async function () {
-      const { button, masterCopy, testSigner, token } = await setup()
+      const {
+        signers: { connext },
+        params,
+        connextModule,
+        button,
+        token,
+      } = await loadFixture(setup)
 
-      const moduleModAddress = await masterCopy.getAddress()
+      const moduleModAddress = await connextModule.getAddress()
       // send some tokens to the connext module, simulates what the connext contract would do.
       await token.transfer(moduleModAddress, 1000)
       // check current number of pushes
       expect(await button.pushes()).to.equal(0)
       // pass bad data to the module, it should revert.
-      const tokenAddress = await token.getAddress()
       await expect(
-        masterCopy.connect(testSigner).xReceive(
+        connextModule.connect(connext).xReceive(
           transferId, // _transferId
           1000, // _amount
-          tokenAddress, // _asset
-          AddressOne, // _originSender
-          1337, // _origin
+          await token.getAddress(), // _asset
+          params.originSender, // _originSender
+          params.origin, // _origin
           "0xbaddad", // _callData
         ),
       ).to.be.reverted
@@ -260,100 +317,91 @@ describe("ConnextModule", function () {
 
   describe("setOriginSender()", function () {
     it("Should revert if caller is not owner", async function () {
-      const { connextModule } = await setup()
-      const [_, nonOwner] = await ethers.getSigners()
-      const nonOwnerMasterCopy = ConnextModule__factory.connect(connextModule.address, nonOwner)
-      await expect(nonOwnerMasterCopy.setOriginSender(AddressOne)).to.be.revertedWithCustomError(
-        nonOwnerMasterCopy,
+      const {
+        signers: { other },
+        connextModule,
+      } = await loadFixture(setup)
+
+      await expect(connextModule.connect(other).setOriginSender(AddressOne)).to.be.revertedWithCustomError(
+        connextModule,
         "OwnableUnauthorizedAccount",
       )
     })
 
     it("Should set originSender and emit OriginSenderSet event", async function () {
-      const { masterCopy, testSigner } = await setup()
-      await expect(masterCopy.connect(testSigner).setOriginSender(AddressOne)).to.emit(masterCopy, "OriginSenderSet")
+      const { connextModule } = await loadFixture(setup)
+      await expect(connextModule.setOriginSender(AddressOne)).to.emit(connextModule, "OriginSenderSet")
     })
   })
 
   describe("setOrigin()", function () {
     it("Should revert if caller is not owner", async function () {
-      const { connextModule } = await setup()
-      const [_, nonOwner] = await ethers.getSigners()
-      const nonOwnerMasterCopy = ConnextModule__factory.connect(connextModule.address, nonOwner)
-      await expect(nonOwnerMasterCopy.setOrigin("0x1234")).to.be.revertedWithCustomError(
-        nonOwnerMasterCopy,
+      const {
+        signers: { other },
+        connextModule,
+      } = await loadFixture(setup)
+
+      const nonOwnerConnextMod = connextModule.connect(other)
+      await expect(nonOwnerConnextMod.setOrigin("0x1234")).to.be.revertedWithCustomError(
+        nonOwnerConnextMod,
         "OwnableUnauthorizedAccount",
       )
     })
 
     it("Should set origin and emit OriginSet event", async function () {
-      const { masterCopy, testSigner } = await setup()
-      await expect(masterCopy.connect(testSigner).setOrigin("0x1234")).to.emit(masterCopy, "OriginSet")
+      const { connextModule } = await loadFixture(setup)
+
+      await expect(connextModule.setOrigin("0x1234")).to.emit(connextModule, "OriginSet")
     })
   })
 
   describe("setConnext()", function () {
     it("Should revert if caller is not owner", async function () {
-      const { connextModule } = await setup()
-      const [_, nonOwner] = await ethers.getSigners()
-      const nonOwnerMasterCopy = ConnextModule__factory.connect(connextModule.address, nonOwner)
-      await expect(nonOwnerMasterCopy.setConnext(AddressOne)).to.be.revertedWithCustomError(
-        nonOwnerMasterCopy,
+      const {
+        signers: { other },
+        connextModule,
+      } = await loadFixture(setup)
+
+      await expect(connextModule.connect(other).setConnext(AddressOne)).to.be.revertedWithCustomError(
+        connextModule,
         "OwnableUnauthorizedAccount",
       )
     })
 
     it("Should set originSender and emit OriginSenderSet event", async function () {
-      const { masterCopy, testSigner } = await setup()
-      await expect(masterCopy.connect(testSigner).setConnext(AddressOne)).to.emit(masterCopy, "ConnextSet")
+      const {
+        signers: { owner },
+        connextModule,
+      } = await loadFixture(setup)
+      await expect(connextModule.connect(owner).setConnext(AddressOne)).to.emit(connextModule, "ConnextSet")
     })
   })
 
   describe("constructor()", function () {
     it("Should setup correct state", async function () {
-      const { masterCopy, params } = await setup()
-      expect(await masterCopy.owner()).to.equal(params.owner)
-      expect(await masterCopy.avatar()).to.equal(params.avatar)
+      const { connextModule, params } = await loadFixture(setup)
+      expect(await connextModule.owner()).to.equal(params.owner)
+      expect(await connextModule.avatar()).to.equal(params.avatar)
       // expect(await masterCopy.target).to.equal(params.target)
-      expect(await masterCopy.originSender()).to.equal(params.originSender)
-      expect(await masterCopy.origin()).to.equal(params.origin)
-      expect(await masterCopy.connext()).to.equal(params.connextAddress)
+      expect(await connextModule.originSender()).to.equal(params.originSender)
+      expect(await connextModule.origin()).to.equal(params.origin)
+      expect(await connextModule.connext()).to.equal(params.connextAddress)
     })
-    it("Should emit ModuleSetUp() event with correct params", async function () {
-      const { masterCopy, params } = await setup()
+    it.skip("Should emit ModuleSetUp() event with correct params", async function () {
+      const { connextModule, params } = await loadFixture(setup)
 
-      const deployTransaction = await masterCopy.deploymentTransaction
-
-      expect(await deployTransaction)
-        .to.emit(masterCopy, "ModuleSetUp")
+      await expect(await connextModule.deploymentTransaction)
+        .to.emit(connextModule, "ModuleSetUp")
         .withArgs(params.owner, params.avatar, params.target, params.originSender, params.origin, params.connextAddress)
     })
   })
 
   describe("setUp()", function () {
     it("Should initialize proxy with correct state", async function () {
-      const { eip1193Provider, masterCopy, params, paramTypes } = await setup()
-      const values = [
-        params.owner,
-        params.avatar,
-        params.target,
-        params.originSender,
-        params.origin,
-        params.connextAddress,
-      ]
-
-      const { address } = await deployProxy({
-        mastercopy: await masterCopy.getAddress(),
-        setupArgs: {
-          types: paramTypes,
-          values,
-        },
-        saltNonce: "0xfa",
-        provider: eip1193Provider,
-      })
+      const { proxyAddress, params } = await loadFixture(setUpWithProxy)
 
       // retrieve new address from event
-      const moduleProxy = await hre.ethers.getContractAt("ConnextModule", address)
+      const moduleProxy = await ConnextModule__factory.connect(proxyAddress, hre.ethers.provider)
 
       expect(await moduleProxy.owner()).to.be.equal(params.owner)
       expect(await moduleProxy.avatar()).to.be.equal(params.avatar)
@@ -361,36 +409,31 @@ describe("ConnextModule", function () {
       expect(await moduleProxy.originSender()).to.equal(params.originSender)
       expect(await moduleProxy.origin()).to.equal(params.origin)
       expect(await moduleProxy.connext()).to.equal(params.connextAddress)
-    }),
-      it("Should emit ModuleSetUp() event with correct params", async function () {
-        const { params } = await setup()
-        const ConnextModule = await ethers.getContractFactory("ConnextModule")
-        const module = await ConnextModule.deploy(
-          params.owner,
-          params.avatar,
-          params.target,
-          params.originSender,
-          params.origin,
-          params.connextAddress,
-        )
-        await module.waitForDeployment()
-        const tx = module.deploymentTransaction()
+    })
+    it("Should emit ModuleSetUp() event with correct params", async function () {
+      const { params } = await loadFixture(setup)
+      const ConnextModule = await ethers.getContractFactory("ConnextModule")
+      const module = await ConnextModule.deploy(
+        params.owner,
+        params.avatar,
+        params.target,
+        params.originSender,
+        params.origin,
+        params.connextAddress,
+      )
+      await module.waitForDeployment()
+      const tx = module.deploymentTransaction()
 
-        expect(tx)
-          .to.emit(module, "ModuleSetUp")
-          .withArgs(
-            params.owner,
-            params.avatar,
-            params.target,
-            params.originSender,
-            params.origin,
-            params.connextAddress,
-          )
-      })
+      expect(tx)
+        .to.emit(module, "ModuleSetUp")
+        .withArgs(params.owner, params.avatar, params.target, params.originSender, params.origin, params.connextAddress)
+    })
+
     it("Should revert if called more than once", async function () {
-      const { params, paramTypes, masterCopy, eip1193Provider } = await setup()
-      const deploySetupArgs = {
-        mastercopy: await masterCopy.getAddress(),
+      const { eip1193Provider, proxyAddress, mastercopyAddress, params, paramTypes } = await loadFixture(setUpWithProxy)
+
+      const { address, noop } = await deployProxy({
+        mastercopy: mastercopyAddress,
         setupArgs: {
           types: paramTypes,
           values: [
@@ -404,10 +447,9 @@ describe("ConnextModule", function () {
         },
         saltNonce: "0xfa",
         provider: eip1193Provider,
-      }
-      await deployProxy(deploySetupArgs)
-      const redeployProxy = await deployProxy(deploySetupArgs)
-      expect(redeployProxy.noop).to.be.equal(true)
+      })
+      expect(noop).to.be.equal(true)
+      expect(address).to.be.equal(proxyAddress)
     })
   })
 })


### PR DESCRIPTION
Two main things:

1. Don't use mastercopy/proxy when testing only core contract logic
2. TODO: A small reorganization of task names. After this discussions we will settle on names to use across packages. 

Current suggestion for task names:
* extract-current-mastercopy: saves into mastercopies.json
* deploy-all-mastercopies  : (goes through the artifacts file, deploys all)
* verify-all-mastercopies :  (goes through the artifacts file, verifies all)
* deploy-current-mastercopy : deploys whatever is in source right now
* verify-current-mastercopy : verifies whatever is in source right now


Notes:
1. the proxy.target bug, is a problem with typechain, we can ignore those asserts
2. I wasn't quite able to recreate the asserts on the contructor event. I think we should move the current "Should emit ModuleSetUp() event with correct params" into the "contructor" section. And we should rewrite the "Should emit ModuleSetUp() event with correct params" using "encodeDeployProxy"
